### PR TITLE
Feat/ssr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Deprecated
+- `defaultActiveTab` on `TabListItem`.
+
+### Added
+- `defaultActiveTabId` on `TabLayout`.
+
+### Changed
+- Make render first tab content if `defaultActiveTabId` is not provided, to correctly render data in SSR.
 
 ## [0.0.2] - 2019-11-05
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ This props should be edited at your theme's `blocks.json`:
 
 | Prop name                  | Type                  | Description                                                                                                   | Default value |
 | -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------- | ------------- |
+| `defaultActiveTabId`             | `String` | Set the id of the tab to be used as default tab. Should match with the value `tabId` of a `tab-list.item`. If not provided, first tab will be used as default.  | `""`   |
 | `blockClass`               | `String`              | Unique class name to be appended to block container class                                                     | `""`          |
 
 #### tab-list
@@ -65,7 +66,6 @@ This props should be edited at your theme's `blocks.json`:
 | `blockClass`             | `String`             | Unique class name to be appended to block container class                                                                  | `""`          |
 | `tabId`                 | `String`              | A `string` used to match the tab to its content item               | `undefined`   |
 | `label`             | `String` | A `string` that determines the tab's text label | `undefined`   |
-| `defaultActiveTab`             | `Boolean` | Set to `true` if this tab should be pre-selected when the page loads (only **one** tab should have this set to `true`)  | `false`   |
 
 #### tab-content
 
@@ -102,17 +102,19 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 }
 ```
 
-### CSS namespaces
+### Customization
 
 Below, we describe the namespaces that are defined by `tab-layout`.
 
-| Class name | Description                |
+| CSS Handle | Description                |
 | ---------- | -------------------------- |
 | `container`  | The container of the entire tabbed layout.    |
 | `listContainer`  | The container of the list of tabs. |
 | `listItem`  | The container of an individual tab. |
 | `contentContainer`  | The container of the tab content items. |
 | `contentItem`  | The container of an individual content item. |
+
+
 
 ## Rules and recommendations
 
@@ -135,7 +137,8 @@ The following creates a `tab-layout` with two tabs labeled "Home 1" and "Home 2"
       "tab-content#home"
     ],
     "props": {
-      "blockClass": "home"
+      "blockClass": "home",
+      "defaultActiveTabId": "home1"
     }
   },
   "tab-list#home": {
@@ -184,3 +187,5 @@ The following creates a `tab-layout` with two tabs labeled "Home 1" and "Home 2"
     }
   }
 ```
+
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization). 

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.css-handles": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/TabContent.tsx
+++ b/react/TabContent.tsx
@@ -1,18 +1,16 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
+const CSS_HANDLES = ['contentContainer']
 
-import styles from './components/TabLayout.css'
-
-const TabContent: StorefrontFunctionComponent<BlockClass> = props => {
-  const { blockClass, children } = props
-
-  const baseClassNames = generateBlockClass(styles.contentContainer, blockClass)
+const TabContent: StorefrontFunctionComponent = props => {
+  const { children } = props
+  const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <div className={`${baseClassNames} w-100`}>
-      {children}
+    <div className={`${handles.contentContainer} w-100`}>
+      {React.Children.map(children, (child, index) => React.cloneElement(child as any, { position: index }))}
     </div>
   )
 }

--- a/react/TabContent.tsx
+++ b/react/TabContent.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { defineMessages } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['contentContainer']
+const CSS_HANDLES = ['contentContainer'] as const
 
 const TabContent: StorefrontFunctionComponent = props => {
   const { children } = props

--- a/react/TabContentItem.tsx
+++ b/react/TabContentItem.tsx
@@ -6,7 +6,7 @@ import {
   useTabState
 } from './components/TabLayoutContext'
 
-const CSS_HANDLES = ['contentItem']
+const CSS_HANDLES = ['contentItem'] as const
 
 interface Props {
   tabId: string

--- a/react/TabContentItem.tsx
+++ b/react/TabContentItem.tsx
@@ -1,26 +1,29 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
 import {
   useTabState
 } from './components/TabLayoutContext'
 
-import styles from './components/TabLayout.css'
+const CSS_HANDLES = ['contentItem']
 
 interface Props {
-    tabId: string
+  tabId: string
+  position: number
 }
 
-const TabContentItem: StorefrontFunctionComponent<Props & BlockClass> = props => {
-  const { blockClass, tabId, children } = props
+const TabContentItem: StorefrontFunctionComponent<Props> = props => {
+  const { tabId, children, position } = props
+  const handles = useCssHandles(CSS_HANDLES)
   const { activeTab } = useTabState()
-  const baseClassNames = generateBlockClass(styles.contentItem, blockClass)
 
-  if (activeTab !== tabId) return null
-  
+  const shouldShow = activeTab === tabId || position === 0
+
+  if (!shouldShow) return null
+
   return (
-    <div className={`${baseClassNames} w-100`}>
+    <div className={`${handles.contentItem} w-100`}>
       {children}
     </div>
   )

--- a/react/TabContentItem.tsx
+++ b/react/TabContentItem.tsx
@@ -18,7 +18,7 @@ const TabContentItem: StorefrontFunctionComponent<Props> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const { activeTab } = useTabState()
 
-  const shouldShow = activeTab === tabId || position === 0
+  const shouldShow = activeTab === tabId || (!activeTab && position === 0)
 
   if (!shouldShow) return null
 

--- a/react/TabLayout.tsx
+++ b/react/TabLayout.tsx
@@ -6,7 +6,7 @@ import {
   TabLayoutContextProvider
 } from './components/TabLayoutContext'
 
-const CSS_HANDLES = ['container']
+const CSS_HANDLES = ['container'] as const
 
 interface Props {
   defaultActiveTabId?: string

--- a/react/TabLayout.tsx
+++ b/react/TabLayout.tsx
@@ -1,23 +1,26 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
 import {
   TabLayoutContextProvider
 } from './components/TabLayoutContext'
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
 
-import styles from './components/TabLayout.css'
+const CSS_HANDLES = ['container']
 
-const TabLayout: StorefrontFunctionComponent<BlockClass> = props => {
-  const { blockClass, children } = props
+interface Props {
+  defaultActiveTabId?: string
+}
 
-  const baseClassNames = generateBlockClass(styles.container, blockClass)
+const TabLayout: StorefrontFunctionComponent<Props> = props => {
+  const { children, defaultActiveTabId = '' } = props
+  const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <TabLayoutContextProvider activeTab={""}>
-        <div className={baseClassNames}>
-            {children}
-        </div>
+    <TabLayoutContextProvider activeTab={defaultActiveTabId}>
+      <div className={handles.container}>
+        {children}
+      </div>
     </TabLayoutContextProvider>
   )
 }

--- a/react/TabList.tsx
+++ b/react/TabList.tsx
@@ -1,18 +1,16 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
+const CSS_HANDLES = ['listContainer']
 
-import styles from './components/TabLayout.css'
-
-const TabList: StorefrontFunctionComponent<BlockClass> = props => {
-  const { blockClass, children } = props
-
-  const baseClassNames = generateBlockClass(styles.listContainer, blockClass)
+const TabList: StorefrontFunctionComponent = props => {
+  const { children } = props
+  const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <div className={`${baseClassNames} flex w-100 flex-wrap justify-center`}>
-      {children}
+    <div className={`${handles.listContainer} flex w-100 flex-wrap justify-center`}>
+      {React.Children.map(children, (child, index) => React.cloneElement(child as any, { position: index }))}
     </div>
   )
 }

--- a/react/TabList.tsx
+++ b/react/TabList.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { defineMessages } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['listContainer']
+const CSS_HANDLES = ['listContainer'] as const
 
 const TabList: StorefrontFunctionComponent = props => {
   const { children } = props

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -1,39 +1,48 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { defineMessages } from 'react-intl'
 
 import { Button } from 'vtex.styleguide'
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
+import { useCssHandles } from 'vtex.css-handles'
+
 import {
   useTabState,
   useTabDispatch
 } from './components/TabLayoutContext'
 
-import styles from './components/TabLayout.css'
+const CSS_HANDLES = ['listItem']
 
 interface Props {
-    tabId: string
-    label: string
-    defaultActiveTab: boolean
+  tabId: string
+  label: string
+  defaultActiveTab: boolean //deprecated
+  position: number
 }
 
-const TabListItem: StorefrontFunctionComponent<Props & BlockClass> = props => {
-  const { blockClass, tabId, label, defaultActiveTab = false } = props
+const TabListItem: StorefrontFunctionComponent<Props> = props => {
+  const { tabId, label, defaultActiveTab, position } = props
+  const handles = useCssHandles(CSS_HANDLES)
   const { activeTab } = useTabState()
   const dispatch = useTabDispatch()
-  const baseClassNames = generateBlockClass(styles.listItem, blockClass)
 
-  if (defaultActiveTab && activeTab === "") dispatch({
-    type: 'changeActiveTab',
+  useEffect(() => {
+    // defaultActiveTab has been deprecated, keep this for compatibility
+    if (defaultActiveTab && activeTab === "") {
+      dispatch({
+        type: 'changeActiveTab',
         payload: { newActiveTab: tabId }
-  })
+      })
+    }
+  }, [])
+
+  const isActive = activeTab === tabId || position === 0
 
   return (
-    <div className={`${baseClassNames} ph2 pv2 ma2`}>
-      <Button variation={activeTab === tabId ? "primary" : "tertiary"} 
-      onClick={() => dispatch({
+    <div className={`${handles.listItem} ph2 pv2 ma2`}>
+      <Button variation={isActive ? "primary" : "tertiary"}
+        onClick={() => dispatch({
           type: 'changeActiveTab',
           payload: { newActiveTab: tabId }
-      })}>
+        })}>
         {label}
       </Button>
     </div>

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -34,7 +34,7 @@ const TabListItem: StorefrontFunctionComponent<Props> = props => {
     }
   }, [])
 
-  const isActive = activeTab === tabId || position === 0
+  const isActive = activeTab === tabId || (!activeTab && position === 0)
 
   return (
     <div className={`${handles.listItem} ph2 pv2 ma2`}>

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -9,7 +9,7 @@ import {
   useTabDispatch
 } from './components/TabLayoutContext'
 
-const CSS_HANDLES = ['listItem']
+const CSS_HANDLES = ['listItem'] as const
 
 interface Props {
   tabId: string

--- a/react/components/TabLayout.css
+++ b/react/components/TabLayout.css
@@ -1,5 +1,0 @@
-.container {}
-.listContainer {}
-.listItem {}
-.contentContainer {}
-.contentItem {}

--- a/react/components/TabLayoutContext.tsx
+++ b/react/components/TabLayoutContext.tsx
@@ -21,23 +21,25 @@ const TabLayoutStateContext = React.createContext<TabLayoutContextProps>(initial
 const TabLayoutDispatchContext = React.createContext<Dispatch | undefined>(undefined)
 
 function reducer(state: TabLayoutContextProps, action: ChangeActiveTabAction): TabLayoutContextProps {
-    switch (action.type) {
-        case 'changeActiveTab':
-            if (action.payload.newActiveTab === state.activeTab) return state
-            return {
-                ...state,
-                activeTab: action.payload.newActiveTab
-            }
-        default:
-            return state
-    }
+  switch (action.type) {
+    case 'changeActiveTab':
+      if (action.payload.newActiveTab === state.activeTab) {
+        return state
+      }
+      return {
+        ...state,
+        activeTab: action.payload.newActiveTab
+      }
+    default:
+      return state
+  }
 }
 
 const TabLayoutContextProvider: FunctionComponent<
   TabLayoutContextProps
-> = ({ children }) => {
+> = ({ children, activeTab }) => {
   const [state, dispatch] = useReducer(reducer, {
-      activeTab: ""
+    activeTab,
   })
   return (
     <TabLayoutStateContext.Provider value={state}>

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@vtex/css-handles": "^1.1.3",
     "ramda": "^0.26.1",
     "react": "^16.8.6",
     "react-intl": "^2.9.0"

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -3,11 +3,7 @@
     "alwaysStrict": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": [
-      "es2017",
-      "dom",
-      "es2018.promise"
-    ],
+    "lib": ["es2017", "dom", "es2018.promise"],
     "module": "es6",
     "moduleResolution": "node",
     "noImplicitAny": true,
@@ -21,23 +17,11 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "es2017",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "types": [
-      "node",
-      "jest",
-      "graphql"
-    ]
+    "typeRoots": ["node_modules/@types"],
+    "types": ["node", "jest", "graphql"]
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "./typings/*.d.ts",
-    "./**/*.tsx",
-    "./**/*.ts"
-  ],
+  "exclude": ["node_modules"],
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],
   "typeAcquisition": {
     "enable": false
   }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react'
-import { TachyonsScaleInput } from '../hooks/tachyons'
 
 declare global {
   interface StorefrontFunctionComponent<P = {}> extends FunctionComponent<P> {
@@ -15,15 +14,5 @@ declare global {
   interface StorefrontElement extends ReactElement {
     schema?: object
     getSchema?(props: P): object
-  }
-
-  interface Gap {
-    colGap: TachyonsScaleInput
-    rowGap: TachyonsScaleInput
-  }
-
-  interface Flex {
-    stretchContent: boolean
-    grow: boolean
   }
 }

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,17 @@
+declare module 'vtex.css-handles' {
+  type CssHandlesInput = readonly string[]
+  type ValueOf<T extends readonly any[]> = T[number]
+  type CssHandles<T extends CssHandlesInput> = Record<ValueOf<T>, string>
+  interface CssHandlesOptions {
+    migrationFrom?: string | string[]
+  }
+
+  export const useCssHandles: <T extends CssHandlesInput>(
+    handles: T,
+    options: CssHandlesOptions = {}
+  ) => CssHandles<T>
+  export const applyModifiers: (
+    handles: string,
+    modifier: string | string[]
+  ) => string
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -120,11 +120,6 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/css-handles@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.3.tgz#30bd1010f2907443188738f74dd11d3b6b4ac624"
-  integrity sha512-DkqnzMf5jW6lQ1L8wYb9fnXyh0FqZym8qEokGYjeLUqBLBAiVK8XbI4U0ezFswWTOJ3iHZUkUjqPt5WodxR29w==
-
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"


### PR DESCRIPTION
#### What problem is this solving?

Today, SSR is not working correctly for items inside tab-layout. For example, with SSR on, the shelf would not be rendered SSR.
Why? because on the first render, activeTab would be `""`, so not tabId would match and all tab content would render null. It is on the second render that active tab has an actual value and then the content is rendered, but this second render is already on client side.

To make SSR work in this component, the father component, TabLayout must know what is the default active tab (so I created this prop).
Also, if this new prop is not set, render the first tab.

https://fidelis--alssports.myvtex.com/

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
