### PR TITLE
Make Tab label editable through Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Make tab label editable through Site Editor.
 
 ## [0.2.0] - 2020-02-05
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "vtex.styleguide": "9.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.native-types": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -4,6 +4,7 @@
   "admin/editor.tabList.title": "admin/editor.tabList.title",
   "admin/editor.tabList.description": "admin/editor.tabList.description",
   "admin/editor.tabListItem.title": "admin/editor.tabListItem.title",
+  "admin/editor.tabListItem.label": "Tab label",
   "admin/editor.tabListItem.description": "admin/editor.tabListItem.description",
   "admin/editor.tabContent.title": "admin/editor.tabContent.title",
   "admin/editor.tabContent.description": "admin/editor.tabContent.description",

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,6 +4,7 @@
   "admin/editor.tabList.title": "Tab List",
   "admin/editor.tabList.description": "Container for tab buttons",
   "admin/editor.tabListItem.title": "Tab List Item",
+  "admin/editor.tabListItem.label": "Tab label",
   "admin/editor.tabListItem.description": "Button with a tabId and label to control visibility of a matching Tab Content Item",
   "admin/editor.tabContent.title": "Tab Content",
   "admin/editor.tabContent.description": "Container for the tab panes",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,6 +4,7 @@
   "admin/editor.tabList.title": "Tab List",
   "admin/editor.tabList.description": "Container for tab buttons",
   "admin/editor.tabListItem.title": "Tab List Item",
+  "admin/editor.tabListItem.label": "Título de la pestaña",
   "admin/editor.tabListItem.description": "Button with a tabId and label to control visibility of a matching Tab Content Item",
   "admin/editor.tabContent.title": "Tab Content",
   "admin/editor.tabContent.description": "Container for the tab panes",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4,6 +4,7 @@
   "admin/editor.tabList.title": "Tab List",
   "admin/editor.tabList.description": "Container for tab buttons",
   "admin/editor.tabListItem.title": "Tab List Item",
+  "admin/editor.tabListItem.label": "Título da aba",
   "admin/editor.tabListItem.description": "Button with a tabId and label to control visibility of a matching Tab Content Item",
   "admin/editor.tabContent.title": "Tab Content",
   "admin/editor.tabContent.description": "Container for the tab panes",

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "TabListItem": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "title": "admin/editor.tabListItem.label",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": ""
+        }
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -10,7 +10,10 @@
     "allowed": ["tab-list.item"]
   },
   "tab-list.item": {
-    "component": "TabListItem"
+    "component": "TabListItem",
+    "content": {
+      "$ref": "app:vtex.tab-layout#/definitions/TabListItem"
+    }
   },
   "tab-content": {
     "component": "TabContent",


### PR DESCRIPTION
#### What problem is this solving?

Make Tab label editable through Site Editor

#### How should this be manually tested?

[Workspace](https://breno--alssports.myvtex.com/admin/cms/site-editor)

#### Checklist/Reminders

- [X] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [X] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/75550578-f2efcd80-5a10-11ea-8836-fbe20189f6ed.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
