### PR TITLE
Empty label validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-- Adding validation when the label is empty
+### Changed
+- Do not render `tab-list.item` if label is empty.
 
 ## [0.4.1] - 2020-11-09
 ### Fixed
-- Update the app documentation
+- Update the app documentation.
 
 ## [0.4.0] - 2020-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - Adding validation when the label is empty
 
 ## [0.4.1] - 2020-11-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Adding validation when the label is empty
 
 ## [0.4.1] - 2020-11-09
 ### Fixed

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -32,7 +32,7 @@ const TabListItem: StorefrontFunctionComponent<Props> = props => {
       payload: { newActiveTab: tabId },
     })
 
-  return label.length > 0 
+  return label?.length > 0 
     ? (
       <div
         className={`${handles.listItem} ${

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -32,21 +32,24 @@ const TabListItem: StorefrontFunctionComponent<Props> = props => {
       payload: { newActiveTab: tabId },
     })
 
-  return label?.length > 0 
-    ? (
-      <div
-        className={`${handles.listItem} ${
-          isActive ? handles.listItemActive : ''
-        } ph2 pv2 ma2`}
+  if (!label || label === '') {
+    return null
+  }
+
+  return (
+    <div
+      className={`${handles.listItem} ${
+        isActive ? handles.listItemActive : ''
+      } ph2 pv2 ma2`}
+    >
+      <Button
+        variation={isActive ? 'primary' : 'tertiary'}
+        onClick={handleClick}
       >
-        <Button
-          variation={isActive ? 'primary' : 'tertiary'}
-          onClick={handleClick}
-        >
-          {label}
-        </Button>
-      </div>
-    ) : null
+        {label}
+      </Button>
+    </div>
+  )
 }
 
 const messages = defineMessages({

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -12,11 +12,14 @@ const CSS_HANDLES = ['listItem', 'listItemActive'] as const
 interface Props {
   tabId: string
   label: string
-  defaultActiveTab: boolean //deprecated
+  /**
+   * @deprecated This prop should not be used
+   */
+  defaultActiveTab: boolean
   position: number
 }
 
-const TabListItem: StorefrontFunctionComponent<Props> = props => {
+function TabListItem(props: Props) {
   const { tabId, label, defaultActiveTab, position } = props
   const handles = useCssHandles(CSS_HANDLES)
   const { activeTab } = useTabState()
@@ -54,11 +57,9 @@ const TabListItem: StorefrontFunctionComponent<Props> = props => {
 
 const messages = defineMessages({
   title: {
-    defaultMessage: '',
     id: 'admin/editor.tabListItem.title',
   },
   description: {
-    defaultMessage: '',
     id: 'admin/editor.tabListItem.description',
   },
 })

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -32,20 +32,21 @@ const TabListItem: StorefrontFunctionComponent<Props> = props => {
       payload: { newActiveTab: tabId },
     })
 
-  return (
-    <div
-      className={`${handles.listItem} ${
-        isActive ? handles.listItemActive : ''
-      } ph2 pv2 ma2`}
-    >
-      <Button
-        variation={isActive ? 'primary' : 'tertiary'}
-        onClick={handleClick}
+  return label.length > 0 
+    ? (
+      <div
+        className={`${handles.listItem} ${
+          isActive ? handles.listItemActive : ''
+        } ph2 pv2 ma2`}
       >
-        {label}
-      </Button>
-    </div>
-  )
+        <Button
+          variation={isActive ? 'primary' : 'tertiary'}
+          onClick={handleClick}
+        >
+          {label}
+        </Button>
+      </div>
+    ) : null
 }
 
 const messages = defineMessages({


### PR DESCRIPTION
#### What problem is this solving?

Do not return the item in the tabs if the label is not filled

#### How to test it?

Just adding tab item with empty label, test only on mobile devices

Workspace: https://tabcontainer--devmcdbrdeliveryio.myvtex.com/catalog

#### Screenshots or example usage:

The first block will show the content because the label is filled, but the second will not appear

![image](https://user-images.githubusercontent.com/38354801/98734260-77f0fc00-2380-11eb-8a31-4c1793383530.png)


Before adjustment, fields that did not exist label occupied space in the viewport

![Print label vazia](https://user-images.githubusercontent.com/38354801/98818824-d662bc80-240a-11eb-8c01-d9be34bb76db.PNG)

After the adjustments, only the items with the filled label appear

![Print lavel validada](https://user-images.githubusercontent.com/38354801/98818968-0a3de200-240b-11eb-9bc5-ca07e9828f89.PNG)

It is possible to create a new item through the admin

![image](https://user-images.githubusercontent.com/38354801/98819284-6e60a600-240b-11eb-9963-4e5f4146ba99.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

Very excited😁

![coding](https://media.giphy.com/media/PiQejEf31116URju4V/giphy.gif)
