### PR TITLE
Uses IOMessage string formatter to translate correclty the tab item label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Uses IOMessage string formatter to translate correclty the tab item label
 
 ## [0.4.2] - 2020-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Fixed
-- Uses IOMessage string formatter to translate correclty the tab item label
+### Fixed
+- Uses IOMessage string formatter to translate correctly the tab item label
 
 ## [0.4.2] - 2020-11-13
-
 ### Changed
 - Do not render `tab-list.item` if label is empty.
 

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -50,7 +50,7 @@ function TabListItem(props: Props) {
         variation={isActive ? 'primary' : 'tertiary'}
         onClick={handleClick}
       >
-        <IOMessage  id={label} />
+        <IOMessage id={label} />
       </Button>
     </div>
   )

--- a/react/TabListItem.tsx
+++ b/react/TabListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { defineMessages } from 'react-intl'
 
 import { Button } from 'vtex.styleguide'
+import { IOMessage } from 'vtex.native-types'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useTabState, useTabDispatch } from './components/TabLayoutContext'
@@ -49,7 +50,7 @@ function TabListItem(props: Props) {
         variation={isActive ? 'primary' : 'tertiary'}
         onClick={handleClick}
       >
-        {label}
+        <IOMessage  id={label} />
       </Button>
     </div>
   )


### PR DESCRIPTION
#### What problem is this solving?
The Tab List Item label was not being translated in multi-language stores.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://fox2--unileverb2b.myvtex.com/?cultureInfo=en-US)

When entering the english page the TabItem `Las Mejores Marcas` should be translated and other content translation should work after being saved.

#### Screenshots or example usage:
<img width="917" alt="Screen Shot 2021-04-09 at 10 02 32 AM" src="https://user-images.githubusercontent.com/12701600/114184060-c21fde80-991a-11eb-82d2-553856ff43ef.png">


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
